### PR TITLE
Remove hard-coded 'blog' and 'note' tags from content providers

### DIFF
--- a/lib/data/providers/Note.ts
+++ b/lib/data/providers/Note.ts
@@ -72,7 +72,7 @@ export class NoteProvider implements IndexableProvider {
     return {
       pageType: "note",
       slug,
-      tags: [...expectTags(page), "note"],
+      tags: expectTags(page),
       title: expectTitle(page, slug),
       summary: expectSummary(page),
       summaryImage: await this._summaryImage(markdown),

--- a/lib/data/providers/Post.ts
+++ b/lib/data/providers/Post.ts
@@ -63,7 +63,7 @@ export class PostProvider implements IndexableProvider {
       content,
       title: metadata.title,
       summary: metadata.summary,
-      tags: [...metadata.tags, "blog"],
+      tags: metadata.tags,
       slug: slug,
       date: date,
       summaryImage,


### PR DESCRIPTION
Previously, the PostProvider was automatically adding a "blog" tag to all
posts, and the NoteProvider was adding a "note" tag to all notes. This
removes that automatic tagging, allowing tags to be managed explicitly
through the content's metadata.